### PR TITLE
HW 8. Terraform-1

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/yandex-cloud/yandex" {
+  version     = "0.108.1"
+  constraints = "0.108.1"
+  hashes = [
+    "h1:oR6DGfiKTbXMxrnoD9cSndJxbAhDG3OgC2PcADwnzL8=",
+    "zh:0c2e12c1c49672d4fd2c650b97fe210431fac8e6a89137637c35fa3d48baee2e",
+    "zh:140c630580ddf5097e87764236ac02540f640e5e02449eb344db8382036d6b85",
+    "zh:2340d4978c8ba99869dfab12fd0339973242dcfa36f6b173ea9ba82eb673443e",
+    "zh:28ab6b9c91df6cfa58c732d7aa84ae8c60b9d5ca9f6e47db8bda014336f71b94",
+    "zh:2f57177c623aebbfb0c9b09b18833c10bed6caf407ae72bcb6379db2a6f27343",
+    "zh:57438a0222dc104a8ebfb998d179750c8b1676bf31b40840cb244b4057fab739",
+    "zh:873abd3a29f5a6a6646d6fc28c26714737617e14bb758385f908ae339dc5427b",
+    "zh:a02062cb07ab22f38faa45c8c9fc2b959cadda5160fd84858d730417f35eef6f",
+    "zh:afbe6fd70e8e5376bc9c2b98eff114f1be7e355a97b8c1f176987b3c33e81522",
+    "zh:c0f22a4b8901aa3a7d83a7477767aa5b501a68f6e68bf74c8596e17d50a62655",
+    "zh:e16ba3032ca06e415e11cce79d83856f0889b9e4fe3fe83ae25513cf6e47919e",
+    "zh:e1a8b15106f05cbbc5c1a516241320f1eafdccebf4aae72809a42731b11379f3",
+    "zh:fd10ef98bf911b224aff8f8a0e78db36820752f73c6df0023da3cd3ac3c9648c",
+  ]
+}

--- a/terraform/files/deploy.sh
+++ b/terraform/files/deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+APP_DIR=${1:-$HOME}
+sleep 40
+sudo apt-get install -y git
+git clone -b monolith https://github.com/express42/reddit.git $APP_DIR/reddit
+cd $APP_DIR/reddit
+bundle install
+sudo mv /tmp/puma.service /etc/systemd/system/puma.service
+sudo systemctl start puma
+sudo systemctl enable puma

--- a/terraform/files/puma.service
+++ b/terraform/files/puma.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Puma HTTP Server
+After=network.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/home/ubuntu/reddit
+ExecStart=/bin/bash -lc 'puma'
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,48 @@
+provider "yandex" {
+    version   = "~> 0.35.0"
+    service_account_key_file = var.yandex_service_account_key_file
+    cloud_id        = var.yandex_cloud_id
+    folder_id       = var.yandex_folder_id
+    zone            = "ru-central1-a"
+}
+
+resource "yandex_compute_instance" "app" {
+  name = "reddit-app"
+
+  resources {
+    cores  = 2
+    memory = 2
+  }
+
+  boot_disk {
+    initialize_params {
+      image_id = var.yandex_image_id
+    }
+  }
+
+  network_interface {
+    subnet_id = var.yandex_subnet_id
+    nat       = true
+  }
+
+  metadata = {
+    ssh-keys = "ubuntu:${file(var.public_key_path)}"
+  }
+
+  connection {
+    type        = "ssh"
+    host        = self.network_interface.0.nat_ip_address
+    user        = "ubuntu"
+    agent       = false
+    private_key = file(var.private_key_path)
+  }
+
+  provisioner "file" {
+    content     = "files/puma.service"
+    destination = "/tmp/puma.service"
+  }
+
+  provisioner "remote-exec" {
+    script = "files/deploy.sh"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "external_ip_address_app" {
+    value = yandex_compute_instance.app.network_interface.0.nat_ip_address
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,8 @@
+yandex_cloud_id             = "xxxxxxxxxxxxxxxxxxxx"
+yandex_folder_id            = "xxxxxxxxxxxxxxxxxxxx"
+service_account_key_file    = "key.json"
+yandex_image_id         = "xxxxxxxxxxxxxxxxxxxx"
+
+
+public_key_path  = "~/.ssh/ubuntu.pub"
+private_key_path = "~/.ssh/ubuntu"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,13 @@
+variable "yandex_cloud_id" {}
+
+variable "yandex_folder_id" {}
+
+variable "yandex_service_account_key_file" {}
+
+variable "yandex_image_id" {}
+
+variable "yandex_subnet_id" {}
+
+variable "public_key_path" {}
+
+variable "private_key_path" {}


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
### проверяем пре-реквизиты

- список образов должен содержать reddit-base-XXXXXXXXXX

```bash
yc compute image list
+----------------------+------------------------+-------------+----------------------+--------+
|          ID          |          NAME          |   FAMILY    |     PRODUCT IDS      | STATUS |
+----------------------+------------------------+-------------+----------------------+--------+
| xxxxxxxxxxxxxxxxxxxx | reddit-full-XXXXXXXXXX | reddit-full | xxxxxxxxxxxxxxxxxxxx | READY  |
| xxxxxxxxxxxxxxxxxxxx | reddit-base-XXXXXXXXXX | reddit-base | xxxxxxxxxxxxxxxxxxxx | READY  |
| xxxxxxxxxxxxxxxxxxxx | reddit-base-XXXXXXXXXX | reddit-base | xxxxxxxxxxxxxxxxxxxx | READY  |
| xxxxxxxxxxxxxxxxxxxx | reddit-full-XXXXXXXXXX | reddit-full | xxxxxxxxxxxxxxxxxxxx | READY  |
+----------------------+------------------------+-------------+----------------------+--------+
```

- в нашем случае, 2 образа подойдут; packer выберет более новый из них. 
- при желании 'освежить' образ (или отсутствии reddit-base-XXXXXXXXXX), собираем новый образ:
- `packer/variables.json` создаем и редактируем, используя `cp packer/variables.json.example packer/variables.json` (подробней в ветке `packer-base`)
-  то же, с парой `packer/key.json.example packer/key.json` (подробней в ветке `packer-base`)
- `cd packer/ && packer build -var-file=./variables.json ./ubuntu16.json`
- устанавливаем terraform, версия ~> 0.12.0.

```bash
terraform -v
Terraform v0.12.30
```

- mkdir terraform && cd terraform
- секцию provider yandex заполняем сначала hardcoded значениями:

```terraform
provider "yandex" {
  token     = "<OAuth или статический ключ сервисного аккаунта>"
  cloud_id  = "<идентификатор облака>"
  folder_id = "<идентификатор каталога>"
  zone      = "ru-central1-a"
}
```

- узнаем нужные id для подстановки:
- `yc config list`

```bash
token: XXXXXXX_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
cloud-id: xxxxxxxxxxxxxxxxxxxx
folder-id: xxxxxxxxxxxxxxxxxxxx
```

- `terraform init`
- убеждаемся в выводе init'а, что версия провайдера yandex соответствует затребованной в дз:
  
```
...
provider.yandex: version = "= 0.108.1"
Terraform has been successfully initialized!
```

 > создаем `resource "yandex_compute_instance"`

 - image_id, subnet_id - согласно инструкции, пока hardcoded.
   - image_id: выбираем нужный из колонки ID вывода `yc compute image list`
   - subnet_id: значение колонки ID нужной строки вывода `yc vpc subnet list` (в моем примере - нужная строка с ZONE="ru-central1-a")
 - `terraform apply`
 - подключаемся к vm
   - `terraform show | grep nat_ip_address`
   - `ssh -i ~/.ssh/ubuntu ubuntu@<найденный_ip_address>`
 >> коннект неуспешен, фиксим передачей ssh public key в инстанс
   - добавляем в `main.tf`, внутри секции `resource "yandex_compute_instance" "app"`:
```
  metadata = {
    ssh-keys = "ubuntu:${file("~/.ssh/ubuntu.pub")}"
  }
```
   - `terraform destroy`
   - `terraform apply`
 - подключаемся к vm: коннект успешен

 - в `outputs.tf` добавляем `output "external_ip_address_app"`
 - `terraform refresh`
```
Outputs:
external_ip_address_app = NN.NN.NN.NN
```
 - в `main.tf` добавляем провиженеры: "file" для puma.service и "remote-exec" для запуска скрипта установки и настройки приложения.
   - подключение провижинеров: секция 
```
connection {
  type = "ssh"
  host = yandex_compute_instance.app.network_interface.0.nat_ip_address
  user = "ubuntu"
  agent = false
  private_key = file("~/.ssh/ubuntu")
}
```
 - `terraform taint yandex_compute_instance.app`
 - `terraform apply`
```
...
Outputs:
external_ip_address_app = NN.NN.NN.NN
```
 - проверяем работу приложения в браузере `http://<external_ip_address_app>:9292`
 - параметризуем переменные: переносим hardcoded vars из `main.tf` в `variables.tf`
   - `cloud_id, folder_id, zone, public_key_path`
   - создаем пару `terraform.tfvars` & `terraform.tfvars.example`; готовим *.example для коммита в git - удаляем psi, не портя неконфиденциальную инфу
```
token            = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
cloud_id         = "xxxxxxxxxxxxxxxxxxxx"
folder_id        = "xxxxxxxxxxxxxxxxxxxx"
zone             = "ru-central1-a" 
...
```
 - `terraform destroy`
 - `terraform apply`
 - проверяем работоспособность приложения 
   - без браузера можно проверить только наличие листенера `nc -vzw1 <external_ip_address_app> 9292`
   - более полную проверку: `curl`; выборочно проверяем контент; для примера берем ф-цию `/login`:
```
curl http://<external_ip_address_app>:9292/login 2>/dev/null | grep -i input 
<input class='form-control' id='username' name='username' placeholder='Your username'>
<input class='form-control' id='password' name='password' placeholder='Your password'>
<input class='btn btn-primary' type='submit' value='Log in'>
```

 > самостоятельные задания

 >> Определите input переменную для приватного ключа...  подключения для провижинеров (connection)

```
variable private_key_path {
  description = "Path to the private key used for ssh access"
}
```

 >> Определите input переменную для задания зоны в ресурсе "yandex_compute_instance" "app". У нее <b>должно</b> быть значение по умолчанию

```
variable zone {
  description = "zone"
  default     = "ru-central1-a"
}

```

 >> Отформатируйте все конфигурационные файлы используя команду `terraform fmt`

 - `terraform fmt`

 >> ...  файл `terraform.tfvars.example`

 - после `git clone`: 
   - `cp <file>.example <file>`
   - редактируем <file> согласно инструкции

## PR checklist
 - [ ] Выставил label с номером домашнего задания
 - [ ] Выставил label с темой домашнего задания
